### PR TITLE
[ISSUE-15] REST endpoints to list available tools

### DIFF
--- a/src/main/java/org/jboss/pnc/pvt/rest/endpoints/ToolsEndPoint.java
+++ b/src/main/java/org/jboss/pnc/pvt/rest/endpoints/ToolsEndPoint.java
@@ -1,0 +1,30 @@
+package org.jboss.pnc.pvt.rest.endpoints;
+
+import java.util.stream.Collectors;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.jboss.pnc.pvt.model.PVTModel;
+import org.jboss.pnc.pvt.rest.model.ToolMeta;
+import org.jboss.pnc.pvt.wicket.PVTApplication;
+
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+
+@Api(value = "/tools", description = "List available tool names")
+@Path("/tools")
+@Produces(MediaType.APPLICATION_JSON)
+public class ToolsEndPoint {
+
+    @ApiOperation(value = "List all available tool names")
+    @GET
+    public Response toolsList() {
+        PVTModel pvtModel = PVTApplication.getDAO().getPvtModel();
+        return Response.ok(pvtModel.getToolsList().stream().map(t -> new ToolMeta(t.getId(), t.getName())).collect(Collectors.toList())).build();
+    }
+
+}

--- a/src/main/java/org/jboss/pnc/pvt/rest/model/ToolMeta.java
+++ b/src/main/java/org/jboss/pnc/pvt/rest/model/ToolMeta.java
@@ -1,0 +1,74 @@
+package org.jboss.pnc.pvt.rest.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+
+/**
+ * A POJO represents Tool's name and id which is easy to use for REST api.
+ *
+ * @author <a href="mailto:lgao@redhat.com">Lin Gao</a>
+ *
+ */
+@JsonAutoDetect
+public class ToolMeta implements Serializable {
+
+    private static final long serialVersionUID = 4800460387333614890L;
+
+    private final String id;
+    private final String name;
+
+    public ToolMeta(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    /**
+     * @return the id
+     */
+    public String getId() {
+        return id;
+    }
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+    /* (non-Javadoc)
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        return result;
+    }
+    /* (non-Javadoc)
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ToolMeta other = (ToolMeta) obj;
+        if (id == null) {
+            if (other.id != null)
+                return false;
+        } else if (!id.equals(other.id))
+            return false;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        return true;
+    }
+
+}


### PR DESCRIPTION
A REST endpoint with path: '/tools' is added to list available tools in JSON format.

Each element in the list contains tool's id and tool's name, the name can be used for other tools to display, and the id can be used to call back as a tool selection.

This fixes https://github.com/yongyang/PVT/issues/15